### PR TITLE
test: 💍 add test for translation function

### DIFF
--- a/translate.test.ts
+++ b/translate.test.ts
@@ -1,0 +1,23 @@
+import translate from "./translate";
+
+describe("Translation Function", () => {
+    test("should return English translation for exact match", () => {
+        expect(translate("データセーフティ", "en", "")).toBe("data safety");
+    });
+
+    test("should return screen-specific translation if screenName is given", () => {
+        expect(translate("WOVN.io", "en", "MainActivity")).toBe("WOVN.io - MainScreen");
+    });
+
+    test("should return default translation if no screenName is given", () => {
+        expect(translate("WOVN.io", "en", "")).toBe("WOVN.io");
+    });
+
+    test("should return Vietnamnese translation for exact match", () => {
+        expect(translate("データセーフティ", "vi", "")).toBe("an toàn dữ liệu");
+    });
+
+    test("should return original text if no translation is found", () => {
+        expect(translate("Non-existing text", "en", "")).toBe("Non-existing text");
+    });
+});


### PR DESCRIPTION
Acceptance criteria:

- [x] Test for - Return the appropriate translation if found for exact match translations
- [x] Test for - Utilize screen-specific translations when available
- [x] Test for - Return the original text if no suitable translation is found